### PR TITLE
Fixes uncaught TypeError & code inspection issues

### DIFF
--- a/EnhanceTestFramework.php
+++ b/EnhanceTestFramework.php
@@ -599,7 +599,7 @@ class EnhanceTestFramework
         if ($parentClassName === 'Enhance\TestFixture') {
             $instance = new $className();
             $this->addFixture($instance);
-        } else {
+        } elseif (is_string($parentClassName)) {
             $ancestorClassName = get_parent_class($parentClassName);
             if ($ancestorClassName === 'Enhance\TestFixture') {
                 $instance = new $className();


### PR DESCRIPTION
Ensure that $parentClassName is a string (can be false, too).

Fixes this error:

~~~
Fatal error: Uncaught TypeError: get_parent_class(): Argument #1 ($object_or_class) must be an object or a valid class name, bool given in /app/tests/EnhanceTestFramework.php:603
Stack trace:
#0 /app/tests/EnhanceTestFramework.php(603): get_parent_class(false)
#1 /app/tests/EnhanceTestFramework.php(587): Enhance\EnhanceTestFramework->addClassIfTest('InternalIterato...')
#2 /app/tests/EnhanceTestFramework.php(536): Enhance\EnhanceTestFramework->getTestFixturesByParent()
#3 /app/tests/EnhanceTestFramework.php(34): Enhance\EnhanceTestFramework->runTests(1)
#4 /app/tests/index.php(6): Enhance\Core::runTests()
#5 {main}
  thrown in /app/tests/EnhanceTestFramework.php on line 603
~~~

Tested with this PHP version:

~~~ 
php --version
PHP 8.2.19 (cli) (built: May 10 2024 22:26:35) (NTS)
~~~ 
