### PR TITLE
refactor: remove closing php tags and multiple eof blank lines

### DIFF
--- a/Code-Spy/ExampleClass.php
+++ b/Code-Spy/ExampleClass.php
@@ -10,4 +10,3 @@ class ExampleClass
         return $a + $b;
     }
 }
-?>

--- a/Code-Spy/ExampleClassTests.php
+++ b/Code-Spy/ExampleClassTests.php
@@ -28,4 +28,3 @@ class ExampleClassTests extends \Enhance\TestFixture
                 \Enhance\Assert::areIdentical(4, $result);
         }
 }
-?>

--- a/Code-Spy/index.php
+++ b/Code-Spy/index.php
@@ -13,6 +13,3 @@ include_once('../EnhanceTestFramework.php');
  \Enhance\Core::discoverTests('.');
 // Run the tests
 \Enhance\Core::runTests();
-?>
-
- 

--- a/EnhanceTestFramework.php
+++ b/EnhanceTestFramework.php
@@ -1845,4 +1845,3 @@ class Localisation
 {
     public $Language = Language::English;
 }
-?>

--- a/First-Test/ExampleAnotherClass.php
+++ b/First-Test/ExampleAnotherClass.php
@@ -22,4 +22,3 @@ class ExampleAnotherClass
         return $x;
     }
 }
-?>

--- a/First-Test/ExampleAnotherClassTests.php
+++ b/First-Test/ExampleAnotherClassTests.php
@@ -13,4 +13,3 @@ class ExampleAnotherClassTests extends \Enhance\TestFixture
         \Enhance\Assert::areIdentical('ABxx', $result);
     }
 }
-?>

--- a/First-Test/ExampleClass.php
+++ b/First-Test/ExampleClass.php
@@ -8,4 +8,3 @@ class ExampleClass
         return $a + $b;
     }
 }
-?>

--- a/First-Test/ExampleClassTests.php
+++ b/First-Test/ExampleClassTests.php
@@ -23,4 +23,3 @@ class ExampleClassTests extends \Enhance\TestFixture
                 \Enhance\Assert::areIdentical(6, $result);
         }
 }
-?>

--- a/First-Test/index.php
+++ b/First-Test/index.php
@@ -7,4 +7,3 @@ include_once('../EnhanceTestFramework.php');
  \Enhance\Core::discoverTests('.');
 // Run the tests
 \Enhance\Core::runTests();
-?>

--- a/Kata/StringCalculator.php
+++ b/Kata/StringCalculator.php
@@ -8,4 +8,3 @@ class StringCalculator
 
     }
 }
-?>

--- a/Kata/StringCalculatorTests.php
+++ b/Kata/StringCalculatorTests.php
@@ -15,4 +15,3 @@ class StringCalculatorTests extends \Enhance\TestFixture
 
         }
 }
-?>

--- a/Kata/index.php
+++ b/Kata/index.php
@@ -5,5 +5,3 @@ include_once('../EnhanceTestFramework.php');
 \Enhance\Core::discoverTests('.');
 // Run the tests
 \Enhance\Core::runTests();
-?>
-

--- a/Self-Test/Assertions/AssertAreIdenticalTestFixture.php
+++ b/Self-Test/Assertions/AssertAreIdenticalTestFixture.php
@@ -62,4 +62,3 @@ class AssertAreIdenticalTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertAreNotIdenticalTestFixture.php
+++ b/Self-Test/Assertions/AssertAreNotIdenticalTestFixture.php
@@ -57,4 +57,3 @@ class AssertAreNotIdenticalTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertContainsTestFixture.php
+++ b/Self-Test/Assertions/AssertContainsTestFixture.php
@@ -35,4 +35,3 @@ class AssertContainsTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertFailTestFixture.php
+++ b/Self-Test/Assertions/AssertFailTestFixture.php
@@ -20,4 +20,3 @@ class AssertFailTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertInconclusiveTestFixture.php
+++ b/Self-Test/Assertions/AssertInconclusiveTestFixture.php
@@ -20,4 +20,3 @@ class AssertInconclusiveTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsArrayTestFixture.php
+++ b/Self-Test/Assertions/AssertIsArrayTestFixture.php
@@ -43,4 +43,3 @@ class AssertIsArrayTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsBoolTestFixture.php
+++ b/Self-Test/Assertions/AssertIsBoolTestFixture.php
@@ -63,4 +63,3 @@ class AssertIsBoolTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsFalseTestFixture.php
+++ b/Self-Test/Assertions/AssertIsFalseTestFixture.php
@@ -36,4 +36,3 @@ class AssertIsFalseTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsFloatTestFixture.php
+++ b/Self-Test/Assertions/AssertIsFloatTestFixture.php
@@ -36,4 +36,3 @@ class AssertIsFloatTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsInstanceOfTypeTestFixture.php
+++ b/Self-Test/Assertions/AssertIsInstanceOfTypeTestFixture.php
@@ -32,4 +32,3 @@ class AssertIsInstanceOfTypeTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsIntTestFixture.php
+++ b/Self-Test/Assertions/AssertIsIntTestFixture.php
@@ -36,4 +36,3 @@ class AssertIsIntTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsNotArrayTestFixture.php
+++ b/Self-Test/Assertions/AssertIsNotArrayTestFixture.php
@@ -44,4 +44,3 @@ class AssertIsNotArrayTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsNotBoolTestFixture.php
+++ b/Self-Test/Assertions/AssertIsNotBoolTestFixture.php
@@ -51,4 +51,3 @@ class AssertIsNotBoolTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsNotFloatTestFixture.php
+++ b/Self-Test/Assertions/AssertIsNotFloatTestFixture.php
@@ -30,4 +30,3 @@ class AssertIsNotFloatTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsNotInstanceOfTypeTestFixture.php
+++ b/Self-Test/Assertions/AssertIsNotInstanceOfTypeTestFixture.php
@@ -32,4 +32,3 @@ class AssertIsNotInstanceOfTypeTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsNotIntTestFixture.php
+++ b/Self-Test/Assertions/AssertIsNotIntTestFixture.php
@@ -30,4 +30,3 @@ class AssertIsNotIntTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsNotNullTestFixture.php
+++ b/Self-Test/Assertions/AssertIsNotNullTestFixture.php
@@ -25,4 +25,3 @@ class AssertIsNotNullTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsNotNumericTestFixture.php
+++ b/Self-Test/Assertions/AssertIsNotNumericTestFixture.php
@@ -47,4 +47,3 @@ class AssertIsNotNumericTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsNotObjectTestFixture.php
+++ b/Self-Test/Assertions/AssertIsNotObjectTestFixture.php
@@ -26,4 +26,3 @@ class AssertIsNotObjectTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsNotScalarTestFixture.php
+++ b/Self-Test/Assertions/AssertIsNotScalarTestFixture.php
@@ -54,4 +54,3 @@ class AssertIsNotScalarTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsNotStringTestFixture.php
+++ b/Self-Test/Assertions/AssertIsNotStringTestFixture.php
@@ -26,4 +26,3 @@ class AssertIsNotStringTestFixture extends \Enhance\TestFixture
     }
 
 }
-?>

--- a/Self-Test/Assertions/AssertIsNullTestFixture.php
+++ b/Self-Test/Assertions/AssertIsNullTestFixture.php
@@ -25,4 +25,3 @@ class AssertIsNullTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsNumericTestFixture.php
+++ b/Self-Test/Assertions/AssertIsNumericTestFixture.php
@@ -35,4 +35,3 @@ class AssertIsNumericTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsObjectTestFixture.php
+++ b/Self-Test/Assertions/AssertIsObjectTestFixture.php
@@ -26,4 +26,3 @@ class AssertIsObjectTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsScalarTestFixture.php
+++ b/Self-Test/Assertions/AssertIsScalarTestFixture.php
@@ -53,4 +53,3 @@ class AssertIsScalarTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertIsStringTestFixture.php
+++ b/Self-Test/Assertions/AssertIsStringTestFixture.php
@@ -26,4 +26,3 @@ class AssertIsStringTestFixture extends \Enhance\TestFixture
     }
 
 }
-?>

--- a/Self-Test/Assertions/AssertIsTrueTestFixture.php
+++ b/Self-Test/Assertions/AssertIsTrueTestFixture.php
@@ -36,4 +36,3 @@ class AssertIsTrueTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/Assertions/AssertNotContainsTestFixture.php
+++ b/Self-Test/Assertions/AssertNotContainsTestFixture.php
@@ -47,4 +47,3 @@ class AssertNotContainsTestFixture extends \Enhance\TestFixture
         $this->target->notContains('Test', 'Some Other String');
     }
 }
-?>

--- a/Self-Test/Assertions/AssertThrowsTestFixture.php
+++ b/Self-Test/Assertions/AssertThrowsTestFixture.php
@@ -72,4 +72,3 @@ class AssertThrowsTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::isTrue($verifyFailed);
     }
 }
-?>

--- a/Self-Test/CodeCoverageLoggerTestFixture.php
+++ b/Self-Test/CodeCoverageLoggerTestFixture.php
@@ -42,4 +42,3 @@ class CodeCoverageLoggerTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::areIdentical(8, $result);
     }
 }
-?>

--- a/Self-Test/CreateOutputTemplateTestFixture.php
+++ b/Self-Test/CreateOutputTemplateTestFixture.php
@@ -8,4 +8,3 @@ class CreateOutputTemplateTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::areIdentical(\Enhance\TemplateType::Xml, $output->getTemplateType());
     }    
 }
-?>

--- a/Self-Test/EnhanceOutputTemplateFactoryTestFixture.php
+++ b/Self-Test/EnhanceOutputTemplateFactoryTestFixture.php
@@ -22,4 +22,3 @@ class EnhanceOutputTemplateFactoryTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::areIdentical(\Enhance\TemplateType::Cli, $output->getTemplateType());
     }    
 }
-?>

--- a/Self-Test/Exclusion/Exclusion.php
+++ b/Self-Test/Exclusion/Exclusion.php
@@ -1,3 +1,2 @@
 <?php
     throw new Exception('This file should have been excluded!');
-?>

--- a/Self-Test/ExpectationTestFixture.php
+++ b/Self-Test/ExpectationTestFixture.php
@@ -44,4 +44,3 @@ class ExpectationTestFixture extends \Enhance\TestFixture
         \Enhance\Assert::areIdentical(1, $target->ExpectedCalls);
     }
 }
-?>

--- a/Self-Test/MockTestFixture.php
+++ b/Self-Test/MockTestFixture.php
@@ -246,4 +246,3 @@ interface IMockExample
     function anotherMethod();
     function callNotExpectedMethod();
 }
-?>

--- a/Self-Test/ScenarioTestFixture.php
+++ b/Self-Test/ScenarioTestFixture.php
@@ -84,4 +84,3 @@ class ScenarioTestFixture extends \Enhance\TestFixture
 		}
 	}
 }
-?>

--- a/Self-Test/index.php
+++ b/Self-Test/index.php
@@ -12,4 +12,3 @@ include_once('../EnhanceTestFramework.php');
 \Enhance\Core::discoverTests('.', true, array('Exclusion'));
 // Run the tests
 \Enhance\Core::runTests();
-?>

--- a/Test-Driven/index.php
+++ b/Test-Driven/index.php
@@ -38,5 +38,3 @@ class ExampleTestFixture extends \Enhance\TestFixture
 }
 
 \Enhance\Core::runTests();
-?>
-

--- a/Website-Tests/Method-Coverage.php
+++ b/Website-Tests/Method-Coverage.php
@@ -15,9 +15,7 @@ class ExampleClassTests extends \Enhance\TestFixture
                 \Enhance\Assert::areIdentical(6, $result);
         }
 }
-?>
 
-<?php
 class ExampleClassTests  extends \Enhance\TestFixture
 {
         public function addTwoNumbersWith3and2Expect5Test()
@@ -34,8 +32,5 @@ class ExampleClassTests  extends \Enhance\TestFixture
                 \Enhance\Assert::areIdentical(6, $result);
         }
 }
-?>
 
-<?php
 $target = \Enhance\Core::getCodeCoverageWrapper('ExampleClassWithConstructor', array(1, 'ArgumentTwo'));
-?>

--- a/Website-Tests/Mocks-And-Stubs.php
+++ b/Website-Tests/Mocks-And-Stubs.php
@@ -15,4 +15,3 @@ class ExampleDependencyClassTests extends \Enhance\TestFixture
                 $mock->verifyExpectations();
         }
 }
-?>

--- a/Website-Tests/Quick-Start-Guide.php
+++ b/Website-Tests/Quick-Start-Guide.php
@@ -50,5 +50,3 @@ class ExampleClassTests extends \Enhance\TestFixture
 
 // Run the tests
 \Enhance\Core::runTests();
-?>
-

--- a/Website-Tests/Test-Classes.php
+++ b/Website-Tests/Test-Classes.php
@@ -5,9 +5,7 @@ include_once('../EnhanceTestFramework.php');
 \Enhance\Core::discoverTests('.');
 // Run the tests
 \Enhance\Core::runTests();
-?>
 
-<?php
 class ExampleClassTests extends \Enhance\TestFixture
 {
         private $target;
@@ -29,5 +27,3 @@ class ExampleClassTests extends \Enhance\TestFixture
                 \Enhance\Assert::areIdentical(6, $result);
         }
 }
-?>
-

--- a/Xml-Output/index.php
+++ b/Xml-Output/index.php
@@ -38,5 +38,3 @@ class ExampleClassTests extends \Enhance\TestFixture
 }
 
 \Enhance\Core::runTests(\Enhance\TemplateType::Xml);
-?>
-

--- a/Xml-Output/tap.php
+++ b/Xml-Output/tap.php
@@ -38,5 +38,3 @@ class ExampleClassTests extends \Enhance\TestFixture
 }
 
 \Enhance\Core::runTests(\Enhance\TemplateType::Tap);
-?>
-

--- a/tempo/index.php
+++ b/tempo/index.php
@@ -28,4 +28,3 @@ class ExampleClassTests extends \Enhance\TestFixture
 }
 
 Enhance\Core::runTests();
-?>


### PR DESCRIPTION
I removed the closing PHP tag `?>` and multiple end-of-file (non-)blank lines from all php files. 

Omitting the closing PHP tag is recommended since many years.

See current PER 2.0 coding style:
https://www.php-fig.org/per/coding-style/#22-files
